### PR TITLE
Add spa control web app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+IAQUALINK_SERIAL=your_device_serial

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+frontend/node_modules
+.env
+.DS_Store
+netlify/functions/node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# iAqualink Spa Control
+
+This project provides a simple guest-facing web interface to control spa features using the iAqualink API. It is intended to be deployed on Netlify and displayed on an iPad in Guided Access mode.
+
+## Features
+
+ - Login page collects your iAqualink credentials
+- Displays current Air, Pool and Spa temperatures
+- Allows toggling of **Spa Mode**, **Spa Heater**, and **Jet Pump** only
+- All other pool equipment is hidden
+
+## Folder Structure
+
+- `frontend/` – React application built with Vite
+- `netlify/functions/` – Serverless functions that proxy requests to the iAqualink API
+- `.env.example` – Example environment variables
+- `netlify.toml` – Netlify build configuration
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and fill in your device serial number.
+3. Run locally with Netlify CLI:
+   ```bash
+   npx netlify dev
+   ```
+
+When deploying to Netlify, add the same environment variable (the device serial) through the Netlify dashboard.
+
+## Building
+
+The build step runs `npm run build` which builds the React app into `frontend/dist`. Netlify will automatically deploy the built site along with the serverless functions.
+
+## Usage
+
+After deployment, open the Netlify URL on an iPad in Safari. Enable Guided Access to restrict user access. Guests will see only the spa controls and current temperatures.
+The first time you access the app, you'll be prompted to log in with your iAqualink credentials. These are never stored in the repository.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spa Control</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spa-panel",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import './style.css';
+
+const FEATURES = {
+  spa_mode: 'Spa Mode',
+  spa_heater: 'Spa Heater',
+  jet_pump: 'Jet Pump'
+};
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const { sessionId } = await res.json();
+      localStorage.setItem('sessionId', sessionId);
+      onLogin(sessionId);
+    } else {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <form className="login" onSubmit={submit}>
+      <h1>Login</h1>
+      {error && <p className="error">{error}</p>}
+      <input
+        type="text"
+        placeholder="Email"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button type="submit">Sign In</button>
+    </form>
+  );
+}
+
+export default function App() {
+  const [sessionId, setSessionId] = useState(localStorage.getItem('sessionId'));
+  const [state, setState] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchStatus = async () => {
+    const res = await fetch('/api/status', {
+      headers: { 'x-session-id': sessionId }
+    });
+    if (res.status === 401) {
+      setSessionId(null);
+      localStorage.removeItem('sessionId');
+      return;
+    }
+    const data = await res.json();
+    setState(data);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (!sessionId) return;
+    fetchStatus();
+    const id = setInterval(fetchStatus, 10000);
+    return () => clearInterval(id);
+  }, [sessionId]);
+
+  const toggle = async feature => {
+    const newState = !state[feature];
+    setState({ ...state, [feature]: newState });
+    await fetch('/api/toggle', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': sessionId
+      },
+      body: JSON.stringify({ feature, state: newState })
+    });
+  };
+
+  if (!sessionId) return <Login onLogin={setSessionId} />;
+
+  if (loading) return <p>Loading...</p>;
+
+  return (
+    <div className="container">
+      <h1>Spa Control</h1>
+      <button className="logout" onClick={() => { localStorage.removeItem('sessionId'); setSessionId(null); }}>Logout</button>
+      <div className="temps">
+        <div>Air: {state.air_temp}°F</div>
+        <div>Pool: {state.pool_temp}°F</div>
+        <div>Spa: {state.spa_temp}°F</div>
+      </div>
+      <div className="controls">
+        {Object.entries(FEATURES).map(([key, label]) => (
+          <button
+            key={key}
+            className={state[key] ? 'active' : ''}
+            onClick={() => toggle(key)}
+          >
+            {label}: {state[key] ? 'On' : 'Off'}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,51 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background: #f0f0f0;
+}
+
+.container {
+  text-align: center;
+}
+
+.temps div {
+  margin: 8px 0;
+  font-size: 1.5rem;
+}
+
+.controls button {
+  display: block;
+  margin: 10px auto;
+  padding: 10px 20px;
+  font-size: 1.2rem;
+}
+
+.login {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  margin: auto;
+}
+
+.login input {
+  margin: 5px 0;
+  padding: 8px;
+  font-size: 1rem;
+}
+
+.login .error {
+  color: red;
+}
+
+.logout {
+  margin-bottom: 20px;
+}
+
+button.active {
+  background: #007bff;
+  color: #fff;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8888'
+    }
+  }
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "frontend/dist"
+  functions = "netlify/functions"
+
+[dev]
+  autoLaunch = false

--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,0 +1,82 @@
+const axios = require('axios');
+
+const BASE_URL = 'https://r-api.iaqualink.net/v1/mobile_app';
+const SERIAL = process.env.IAQUALINK_SERIAL;
+const sessions = {};
+
+async function iaqualinkLogin(username, password) {
+  const res = await axios.post(`${BASE_URL}/login`, {
+    email: username,
+    password,
+    app_version: '1.0.0',
+  });
+  return res.data.authentication_token;
+}
+
+async function iaqualinkRequest(token, path, method = 'get', data) {
+  const res = await axios({
+    method,
+    url: `${BASE_URL}${path}`,
+    headers: { Authorization: `Bearer ${token}` },
+    data,
+  });
+  return res.data;
+}
+
+exports.handler = async function(event) {
+  const { path, httpMethod } = event;
+  const route = path.replace('/.netlify/functions/api', '');
+
+  try {
+    if (route === '/login' && httpMethod === 'POST') {
+      const { username, password } = JSON.parse(event.body || '{}');
+      if (!username || !password) {
+        return { statusCode: 400, body: 'Missing credentials' };
+      }
+      try {
+        const token = await iaqualinkLogin(username, password);
+        const sessionId = Math.random().toString(36).slice(2);
+        sessions[sessionId] = token;
+        return { statusCode: 200, body: JSON.stringify({ sessionId }) };
+      } catch (e) {
+        return { statusCode: 401, body: 'Invalid credentials' };
+      }
+    }
+
+    const sessionId = event.headers['x-session-id'];
+    const token = sessions[sessionId];
+    if (!token) {
+      return { statusCode: 401, body: 'Unauthorized' };
+    }
+
+    if (route === '/status' && httpMethod === 'GET') {
+      const data = await iaqualinkRequest(token, `/devices/${SERIAL}/home`);
+      const result = {
+        air_temp: data.air_temp,
+        pool_temp: data.pool_temp,
+        spa_temp: data.spa_temp,
+        spa_mode: data.spa_mode,
+        spa_heater: data.spa_heater,
+        jet_pump: data.jet_pump,
+      };
+      return {
+        statusCode: 200,
+        body: JSON.stringify(result),
+      };
+    }
+
+    if (route === '/toggle' && httpMethod === 'POST') {
+      const body = JSON.parse(event.body || '{}');
+      const { feature, state } = body;
+      if (!['spa_mode','spa_heater','jet_pump'].includes(feature)) {
+        return { statusCode: 400, body: 'Invalid feature' };
+      }
+      await iaqualinkRequest(token, `/devices/${SERIAL}/set_${feature}`, 'post', { value: state ? 'on' : 'off' });
+      return { statusCode: 200, body: 'ok' };
+    }
+
+    return { statusCode: 404, body: 'Not Found' };
+  } catch (e) {
+    return { statusCode: 500, body: e.message };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "iaqualink-spa-control",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "npm --prefix frontend run build",
+    "dev": "npm --prefix frontend run dev",
+    "start": "npm --prefix frontend start"
+  },
+  "dependencies": {
+    "axios": "^1.5.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Netlify config and environment example
- add serverless API function to talk to iAqualink
- implement React frontend with spa-only controls and login page
- document setup and usage

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753d1c7a38832bb3ba6b49c0da62c2