### PR TITLE
Add postinstall and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ This project provides a simple guest-facing web interface to control spa feature
 
 ## Setup
 
-1. Install dependencies:
+1. Install dependencies at the project root. The `postinstall` script will also
+   install the `frontend/` dependencies:
    ```bash
    npm install
+   ```
+   Alternatively, you can run the following to install the frontend dependencies directly:
+   ```bash
+   npm install --prefix frontend
    ```
 2. Copy `.env.example` to `.env` and fill in your device serial number.
 3. Run locally with Netlify CLI:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "npm --prefix frontend run build",
     "dev": "npm --prefix frontend run dev",
-    "start": "npm --prefix frontend start"
+    "start": "npm --prefix frontend start",
+    "postinstall": "npm --prefix frontend install"
   },
   "dependencies": {
     "axios": "^1.5.0"


### PR DESCRIPTION
## Summary
- automatically install frontend dependencies via `postinstall`
- document the behaviour in the setup section of the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68757bc47464832bbe6170b686399442