### PR TITLE
Add AUX circuit status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ npm run build
 - 🛡️ **Session Management**: Automatic token refresh
 - 🌊 **Spa API**: RESTful endpoints for spa control
 - 📊 **Status Monitoring**: Real-time temperature and device status
+- 🔌 **AUX Status API**: Query circuit states including jets
 - 🚦 **Rate Limiting**: Built-in API protection
 - 🔗 **CORS**: Configurable cross-origin support
 
@@ -233,6 +234,7 @@ Notes:
 2. Test API endpoints directly:
    ```bash
    curl https://your-backend-url.fly.dev/api/status
+   curl https://your-backend-url.fly.dev/api/aux-status
    ```
 3. Verify iAqualink credentials in official app
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,6 +54,9 @@ Toggles a spa device on/off.
 ### GET /api/devices
 Returns information about available devices.
 
+### GET /api/aux-status
+Returns current AUX circuit states including labels.
+
 ### GET /health
 Health check endpoint.
 ### POST /api/check-location

--- a/backend/src/routes/spa.js
+++ b/backend/src/routes/spa.js
@@ -19,6 +19,20 @@ router.get('/status', async (req, res) => {
   }
 });
 
+// Get AUX circuit status
+router.get('/aux-status', async (req, res) => {
+  try {
+    const aux = await iaqualinkService.getDeviceStatus();
+    res.json(aux);
+  } catch (error) {
+    console.error('Error getting aux status:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve aux status',
+      message: error.message,
+    });
+  }
+});
+
 // Toggle spa device
 let shutdownTimer = null;
 const AUTO_SHUTDOWN_MS = 3 * 60 * 60 * 1000; // 3 hours


### PR DESCRIPTION
## Summary
- add `getDeviceStatus` method to fetch AUX circuit states
- extend `getSpaStatus` to include AUX details
- expose `/api/aux-status` endpoint
- document AUX status endpoint in READMEs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ceb7dfe60832bac3a0231b72862f0