### PR TITLE
Add deploy script

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,6 +39,11 @@ npm run build
 
 The built files will be in the `dist` directory.
 
+To rebuild the app and copy the output to the repository `docs/` folder, run:
+```bash
+npm run deploy
+```
+
 ## GitHub Pages Deployment
 
 1. Push your code to GitHub

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "npm run build && cp -r dist/* ../docs/"
   },
   "dependencies": {
     "axios": "^1.4.0",


### PR DESCRIPTION
## Summary
- add `deploy` script for publishing to `docs/`
- document how to use the deploy script

## Testing
- `npm test` (backend)
- `npm test` (frontend, expected failure)

------
https://chatgpt.com/codex/tasks/task_e_687de12ef8d8832baa97f52b0166c7a3