### PR TITLE
Add spa hours lockout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,11 @@ import {
   getAllKeys
 } from './services/spaAPI';
 
+const getWithinSpaHours = () => {
+  const hour = new Date().getHours();
+  return hour >= 6 && hour < 22; // 6am - 10pm
+};
+
 function App() {
   const location = useLocation();
   const isAdminRoute = location.pathname.startsWith('/admin');
@@ -22,6 +27,7 @@ function App() {
   const [isAdmin, setIsAdmin] = useState(null);
   const [reservations, setReservations] = useState([]);
   const [locationAllowed, setLocationAllowed] = useState(null);
+  const [withinSpaHours, setWithinSpaHours] = useState(getWithinSpaHours());
   const [spaData, setSpaData] = useState({
     spaMode: false,
     spaHeater: false,
@@ -182,6 +188,13 @@ const handleLogin = (key) => {
   }, [authenticated]);
 
   useEffect(() => {
+    const interval = setInterval(() => {
+      setWithinSpaHours(getWithinSpaHours());
+    }, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
    if (!authenticated || !isAdminRoute) return;
     checkAdmin();
   }, [authenticated, isAdminRoute]);
@@ -203,6 +216,7 @@ const handleLogin = (key) => {
         <h1>🌊 Spa Control</h1>
         <p>Guest Control Panel</p>
         <p>Status: {spaData.connected ? '🟢 Connected' : '🔴 Disconnected'}</p>
+        <p>Spa hours: 6am-10pm</p>
       </header>
 
 
@@ -222,7 +236,7 @@ const handleLogin = (key) => {
           jetPump={spaData.jetPump}
           filterPump={spaData.filterPump}
           onToggle={handleToggle}
-          disabled={loading}
+          disabled={loading || !withinSpaHours}
         />
       </main>
 

--- a/frontend/src/components/SpaControls.jsx
+++ b/frontend/src/components/SpaControls.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function SpaControls({ spaMode, jetPump, filterPump, onToggle }) {
+function SpaControls({ spaMode, jetPump, filterPump, onToggle, disabled }) {
   const state = { spaMode, jetPump, filterPump };
 
   return (
@@ -9,17 +9,23 @@ function SpaControls({ spaMode, jetPump, filterPump, onToggle }) {
       <div className="ctrl-grid">
         <button
           className={`ctrl-btn ${spaMode ? 'active danger' : ''}`}
-          onClick={() => onToggle('spa')}>
+          onClick={() => onToggle('spa')}
+          disabled={disabled}
+        >
           🛁 <span className="label">Spa</span>
         </button>
         <button
           className={`ctrl-btn ${jetPump ? 'active' : ''}`}
-          onClick={() => onToggle('jet-pump')}>
+          onClick={() => onToggle('jet-pump')}
+          disabled={disabled}
+        >
           💨 <span className="label">Jet</span>
         </button>
         <button
           className={`ctrl-btn ${filterPump ? 'active' : ''}`}
-          onClick={() => onToggle('filter-pump')}>
+          onClick={() => onToggle('filter-pump')}
+          disabled={disabled}
+        >
           🌊 <span className="label">Filter</span>
         </button>
       </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -79,6 +79,7 @@ h2{
 .ctrl-btn:active{transform:scale(.96)}
 .ctrl-btn.active{background:var(--success);color:#fff}
 .ctrl-btn.danger.active{background:var(--danger)}
+.ctrl-btn:disabled{opacity:.5;pointer-events:none}
 
 /* grid wrapper */
 .ctrl-grid{


### PR DESCRIPTION
## Summary
- disable spa control buttons from 10 pm to 6 am
- show spa hours message in header
- style disabled buttons

## Testing
- `npm install` in `frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688290b0e228832ba24e57aae48ae7cc