### PR TITLE
Fix active guest link logic

### DIFF
--- a/backend/src/routes/keys.js
+++ b/backend/src/routes/keys.js
@@ -3,19 +3,21 @@ import accessKeyService from '../services/accessKeyService.js';
 
 const router = express.Router();
 
-// List all access keys with reservation dates
+// Return the currently active reservation
 router.get('/', (req, res) => {
   const key = req.headers['x-access-key'];
   if (key !== process.env.ACCESS_KEY) {
     return res.status(403).json({ error: 'Forbidden' });
   }
-  const reservations = accessKeyService.getActiveReservations().map((r) => ({
-    code: r.code,
-    url: accessKeyService.generateUrl(r.code),
-    start: r.start,
-    end: r.end,
-  }));
-  res.json({ reservations });
+  const [r] = accessKeyService.getActiveReservations();
+  const reservation =
+    r && {
+      code: r.code,
+      url: accessKeyService.generateUrl(r.code),
+      start: r.start,
+      end: r.end,
+    };
+  res.json({ reservation });
 });
 
 export default router;

--- a/backend/src/services/accessKeyService.js
+++ b/backend/src/services/accessKeyService.js
@@ -63,23 +63,28 @@ class AccessKeyService {
   isActive(reservation) {
     const now = new Date();
     const start = new Date(reservation.start);
-    // links become active roughly an hour before the 4 PM check-in
-    start.setHours(15, 0, 0, 0); // 3 PM arrival day
+    // Links become active roughly an hour before the 4 PM check-in
+    // (check-in is 4 PM, so activate around 3 PM on arrival day)
+    start.setHours(15, 0, 0, 0);
     const end = new Date(reservation.end);
-    // use the checkout date itself and allow a cushion past 11 AM
-    end.setHours(13, 0, 0, 0); // 1 PM checkout day
+    // Allow roughly two hours past the 11 AM checkout time
+    end.setHours(13, 0, 0, 0); // 1 PM on departure day
     return now >= start && now <= end;
   }
 
   async validateKey(key) {
     if (key === this.adminKey) return true;
-    return this.reservations.some(
-      (r) => r.code === key && this.isActive(r)
-    );
+    const current = this.getCurrentReservation();
+    return current && current.code === key;
   }
 
   getActiveReservations() {
-    return this.reservations.filter((r) => this.isActive(r));
+    const current = this.getCurrentReservation();
+    return current ? [current] : [];
+  }
+
+  getCurrentReservation() {
+    return this.reservations.find((r) => this.isActive(r)) || null;
   }
 
   getAllReservations() {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import {
   toggleSpaDevice,
   setSpaTemperature,
   checkLocation,
-  getAllKeys
+  getActiveReservation
 } from './services/spaAPI';
 
 const getWithinSpaHours = () => {
@@ -66,8 +66,8 @@ const [loading, setLoading] = useState(true);
 
   const checkAdmin = async () => {
     try {
-      const res = await getAllKeys();
-      setReservations(res);
+      const res = await getActiveReservation();
+      setReservations(res ? [res] : []);
       setIsAdmin(true);
       return true;
     } catch (err) {

--- a/frontend/src/services/spaAPI.js
+++ b/frontend/src/services/spaAPI.js
@@ -64,9 +64,9 @@ export const checkLocation = async (latitude, longitude) => {
   }
 };
 
-export const getAllKeys = async () => {
+export const getActiveReservation = async () => {
   const res = await api.get('/api/keys');
-  return res.data.reservations;
+  return res.data.reservation || null;
 };
 
 export const validateAccessKey = async (key) => {


### PR DESCRIPTION
## Summary
- ensure access code is validated only for the current reservation
- return only one active reservation in `/api/keys`
- expose `getActiveReservation` on the frontend API
- show the single active reservation in admin panel logic

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885a6df4880832b91b09823351d37d6