### PR TITLE
Fix frontend going offline due to cascading AUX status failures

### DIFF
--- a/backend/src/services/iaqualink.js
+++ b/backend/src/services/iaqualink.js
@@ -168,7 +168,12 @@ class IaqualinkService {
       const rawJet = jetKey ? flatStatus[jetKey] : undefined;
       const jetPumpStatus = ['1', 1, 'on', 'ON', true].includes(rawJet);
 
-      const auxDetails = await this.getDeviceStatus();
+      let auxDetails = null;
+      try {
+        auxDetails = await this.getDeviceStatus();
+      } catch (auxErr) {
+        console.warn('⚠️ AUX status fetch failed (non-fatal):', auxErr.message);
+      }
 
       // Prefer AUX circuit status for jet pump if available
       let jetPumpActual = jetPumpStatus;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -258,7 +258,7 @@ function App() {
       }
       setStatusFailures((prev) => {
         const next = prev + 1;
-        if (next >= 3) {
+        if (next >= 5) {
           setSpaData((prevData) => ({ ...prevData, connected: false }));
         }
         return next;

--- a/frontend/src/services/spaAPI.js
+++ b/frontend/src/services/spaAPI.js
@@ -4,7 +4,7 @@ const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001'
 
 const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 20000,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
- Wrap getDeviceStatus() in try-catch inside getSpaStatus() so a flaky iAqualink AUX/devices API call no longer kills the entire status response and triggers a frontend 500 error
- Raise the frontend offline threshold from 3 to 5 consecutive failures so transient errors (e.g. sleeping free-tier backend) don't immediately flip the UI to Offline
- Increase frontend API timeout from 10s to 20s to accommodate cold-start wakeup on free-tier hosting

https://claude.ai/code/session_01WG8Qru4sbJ2BhhHCUsgbiE